### PR TITLE
to_paf: adding a --preserve_breakpoint option

### DIFF
--- a/chaintools/test_utils.py
+++ b/chaintools/test_utils.py
@@ -31,6 +31,31 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(utils.reverse_complement("TCGAN"), "NTCGA")
 
 
+class TestChain(unittest.TestCase):
+    """Tests of the Chain class."""
+
+    def test_update_cigar_indel_simple(self):
+        c = utils.Chain()
+        c.cigarstring = ""
+        c.nm_tag_val = 0
+        c.strand = "+"
+        queryendpos = c.update_cigar_indel(deltaq=0, deltat=1)
+        self.assertEqual(c.cigarstring, "1D")
+        self.assertEqual(queryendpos, 0)
+        queryendpos = c.update_cigar_indel(deltaq=2, deltat=0)
+        self.assertEqual(c.cigarstring, "1D2I")
+        self.assertEqual(queryendpos, 2)
+
+    def test_update_cigar_indel_breakpoint(self):
+        c = utils.Chain()
+        c.cigarstring = ""
+        c.nm_tag_val = 0
+        c.strand = "+"
+        queryendpos = c.update_cigar_indel(deltaq=2000, deltat=300)
+        self.assertEqual(c.cigarstring, "2000I300D")
+        self.assertEqual(queryendpos, 2000)
+
+
 class TestReadingChain(unittest.TestCase):
     """Tests reading a chain file."""
 
@@ -146,7 +171,7 @@ class TestGenerateSAM(unittest.TestCase):
         )
 
 
-class TestGeneratePAF(unittest.TestCase):
+class TestPaf(unittest.TestCase):
     def generate_and_check(self, chainfn, targetfn, queryfn, paffn):
         targetref = utils.fasta_reader(targetfn)
         queryref = utils.fasta_reader(queryfn)

--- a/chaintools/utils.py
+++ b/chaintools/utils.py
@@ -372,9 +372,15 @@ class Chain(ChainConst):
             updated queryendpos
         """
         if deltaq < 0:
-            raise ValueError(f"deltaq should not be negative. Got {deltaq=}")
+            # TODO use `f"{deltaq=}"` when we don't support py3.7
+            raise ValueError(
+                f"deltaq should not be negative. Got deltaq: {deltaq}"
+            )
         if deltat < 0:
-            raise ValueError(f"deltat should not be negative. Got {deltat=}")
+            # TODO use `f"{deltat=}"` when we don't support py3.7
+            raise ValueError(
+                f"deltat should not be negative. Got deltat: {deltat}"
+            )
         if deltaq > 0:
             self.cigarstring += f"{deltaq}I"
             self.nm_tag_val += deltaq

--- a/chaintools/utils.py
+++ b/chaintools/utils.py
@@ -371,10 +371,14 @@ class Chain(ChainConst):
         Returns:
             updated queryendpos
         """
+        if deltaq < 0:
+            raise ValueError(f"deltaq should not be negative. Got {deltaq=}")
+        if deltat < 0:
+            raise ValueError(f"deltat should not be negative. Got {deltat=}")
         if deltaq > 0:
             self.cigarstring += f"{deltaq}I"
             self.nm_tag_val += deltaq
-        else:
+        if deltat > 0:
             self.cigarstring += f"{deltat}D"
             self.nm_tag_val += deltat
         if self.strand == "+":
@@ -468,7 +472,10 @@ class Chain(ChainConst):
         return queryendpos
 
     def to_paf(
-        self, targetref: pysam.FastaFile, queryref: pysam.FastaFile
+        self,
+        targetref: pysam.FastaFile,
+        queryref: pysam.FastaFile,
+        preserve_breakpoint: bool = False,
     ) -> str:
         for i, intvl in enumerate(sorted(self.ttree.all_intervals)):
             # deal with indels first, because they are to the left of the
@@ -479,7 +486,7 @@ class Chain(ChainConst):
                 deltaq = intvl.data[2]
 
                 # Reduces breakpoints
-                if deltaq > 0 and deltat > 0:
+                if deltaq > 0 and deltat > 0 and not preserve_breakpoint:
                     min_delta = min([deltat, deltaq])
                     self.cigarstring += f"{min_delta}X"
                     if deltaq > min_delta:


### PR DESCRIPTION
When `--preserve_breakpoint` is set to `True`, `chaintools.to_paf()` preserves all breakpoints.

Example:
The gap specified by `149 341 2894` would be converted to `149M2894I341D` with `--preserve_breakpoint`. Without the option, it is converted to `149M341X2553I`