### PR TITLE
Tests python 3.8-3.11

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout repository

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,7 @@ uv sync
 
 ## Requirements
 
-- Python ≥3.7
+- Python ≥3.8
 - pysam ≥0.15.3
 - intervaltree ≥3.1.0
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Lift-over software such as [UCSC LiftOver](https://genome.ucsc.edu/cgi-bin/hgLif
 git clone git@github.com:milkschen/chaintools.git
 ```
 
-- Python 3.7+
+- Python 3.8+
 - Dependencies: [intervaltree](https://github.com/chaimleib/intervaltree), [pandas](https://pandas.pydata.org), and [pysam](https://pysam.readthedocs.io/en/latest/). See [INSTALL.md](INSTALL.md) for instructions.
 
 ## Usage


### PR DESCRIPTION
* Python 3.7 has reached end-of-life, so removed from the GitHub Action tests.
* 3.8 has also reached EOL, but it seems like we can still use it with `ubuntu-latest`, so keep it for now.
* Additionally test for Python 3.11.