### PR TITLE
Deprecate python 3.7 in the next release

### DIFF
--- a/chaintools/__init__.py
+++ b/chaintools/__init__.py
@@ -1,0 +1,13 @@
+import sys
+import logging
+
+if sys.version_info < (3, 8):
+    logging.warning(
+        "chaintools will require Python 3.8 or higher in the next release. "
+        "Current version: %s",
+        sys.version,
+    )
+    # raise RuntimeError(
+    #     "chaintools requires Python 3.8 or higher. "
+    #     f"Current version: {sys.version}"
+    # )


### PR DESCRIPTION
Shows a warning if using python <3.8